### PR TITLE
Build from golang:1.19-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/go AS build
+FROM golang:1.19-alpine AS build
 ADD ./ /src
 RUN cd /src && CGO_ENABLED=0 go build -o /bin/gcb2gh .
 


### PR DESCRIPTION
Partially because I wanted to ensure the certificate authorities were up-to-date.

I've already built and pushed our image as `sha256:1c14093d391dbbcba16b21718313f7f4e73a2721d70da4dc8cb53162dd2df256`